### PR TITLE
Update react-native-localize from 2.2.3 to 3.0.4

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,6 @@
 process.env.JEST = 'true'
 
-jest.mock('react-native-localize', () => require('react-native-localize/mock.js'))
+jest.mock('react-native-localize', () => require('react-native-localize/mock'))
 jest.mock('i18n-js', () => {
   class I18nMock {
     store = () => jest.fn()

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "i18n-js": "^4.1.1",
-    "react-native-localize": "^2.2.3"
+    "react-native-localize": "^3.0.4"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export const initLocalify = <
   const language = process.env.JEST
     ? { languageTag: 'en' }
     : /* istanbul ignore next */ // NOTE: Excluding native module from Jest coverage.
-      RNLocalize.findBestAvailableLanguage(Object.keys(i18n.translations)) || fallback
+      RNLocalize.findBestLanguageTag(Object.keys(i18n.translations)) || fallback
 
   languageTag = language.languageTag
   i18n.locale = language.languageTag

--- a/yarn.lock
+++ b/yarn.lock
@@ -8013,10 +8013,10 @@ react-native-gradle-plugin@^0.0.6:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.6.tgz#b61a9234ad2f61430937911003cddd7e15c72b45"
   integrity sha512-eIlgtsmDp1jLC24dRn43hB3kEcZVqx6DUQbR0N1ABXGnMEafm9I3V3dUUeD1vh+Dy5WqijSoEwLNUPLgu5zDMg==
 
-react-native-localize@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-2.2.3.tgz#9666becaea5d6b8d968f037d82b2220ba52c463b"
-  integrity sha512-DoEEk7s4p0BnCU2zS2yzC+bEUWSFhcuXoLidgHag1EQkaXJLiNos661h8nGZvWWrVK6zE+Cl2319bqG3FidkJQ==
+react-native-localize@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.0.4.tgz#70bb6212cee4dd9eaabb65a4a6227dca5b7faf5e"
+  integrity sha512-O6NnwsdorLiK5PCulfiKSnNjBW8B0m1HO24MQOgSC2iHiZZWMCA2to7Ln5EOagaGPsqq5UbgisR2bpycoMPYaw==
 
 react-native@0.68.2:
   version "0.68.2"


### PR DESCRIPTION
This PR updates react-native-localize version from 2.2.3 to 3.0.4.